### PR TITLE
docs: fix links to Node and React Native installation pages

### DIFF
--- a/guides/getting-started/index.md
+++ b/guides/getting-started/index.md
@@ -1,5 +1,5 @@
 # Getting started
 
-In this section we will go over everything you need to get started on a technical level. First there are specific installation guides for NodeJS and React Native. Aries JavaScript works for creating both serverside application (commonly but not always issuer and verifyer) and mobile applications (commonly holder apps). Depending on your use case you can follow the installation guides for [NodeJS](./installation/nodejs/index.md), [React Native](/installation/react-native/index.md), or both.
+In this section we will go over everything you need to get started on a technical level. First there are specific installation guides for NodeJS and React Native. Aries JavaScript works for creating both serverside application (commonly but not always issuer and verifyer) and mobile applications (commonly holder apps). Depending on your use case you can follow the installation guides for [NodeJS](./installation/nodejs/index.md), [React Native](./installation/react-native/index.md), or both.
 
 After the installation of your prerequisites is complete, we'll walk you through the [initial setup](./set-up/index.md) of the framework.

--- a/guides/getting-started/installation/index.md
+++ b/guides/getting-started/installation/index.md
@@ -8,11 +8,10 @@ Very simply put:
 
 **Do you want to build a mobile app?**
 
-- Have [NodeJS](https://nodejs.org/en/) installed (but no need to follow the [NodeJS installation](./installation/nodejs/index.md) guide as it pertains to the `@aries-framework/node` package).
-- Follow the [React Native installation](./installation/react-native/index.md) guide.
+- Follow the [React Native installation](./react-native/index.md) guide.
 - Follow the [set up](./../set-up/index.md) guide.
 
 **Do you want to build a server-side app?**
 
-- Follow the [NodeJS installation](./installation/nodejs/index.md) guide.
+- Follow the [NodeJS installation](./nodejs/index.md) guide.
 - Follow the [set up](./../set-up/index.md) guide.


### PR DESCRIPTION
I tried it locally and it worked.

I also removed the mention of NodeJS as a prerequisite for mobile app development because that's already part of React Native prerequisites.