### PR TITLE
docs: update migration guide with new breaking changes

### DIFF
--- a/guides/updating/versions/0.2-to-0.3.md
+++ b/guides/updating/versions/0.2-to-0.3.md
@@ -68,7 +68,7 @@ Note that, if you are defining `indyLedgers` configuration, you should set the i
 
 ### did:key usage in protocols
 
-In accordance with [Aries RFC 0360](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0360-use-did-key), since 0.2.5 there is a configuration parameter called `useDidKeyInProtocols` which, when enabled, will encode keys in did:key instead of previous base58 format, unless the other party has started a protocol and is using base58. 
+In accordance with [Aries RFC 0360](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0360-use-did-key), since 0.2.5 there is a configuration parameter called `useDidKeyInProtocols` which, when enabled, will encode keys in did:key instead of previous base58 format, unless the other party has started a protocol and is using base58.
 
 This parameter was previously disabled by default and now it is enabled. If your agent only interacts with modern agents (e.g. AFJ 0.2.5 and newer) this will not represent any issue. Otherwise it is safer to explicitly set it to `false`. However, keep in mind that we expect this setting to be deprecated in the future, so we encourage you to update all your agents to use did:key.
 
@@ -462,7 +462,7 @@ You can take advantage of this new mechanism to associate a record to the contex
 #### 0.2.x
 
 ```ts
-import { createOutboundMessage } from '@aries-framework/core' 
+import { createOutboundMessage } from '@aries-framework/core'
 
 const outboundMessage = createOutboundMessage(connection, message)
 await this.messageSender.sendMessage(outboundMessage)
@@ -471,14 +471,14 @@ await this.messageSender.sendMessage(outboundMessage)
 #### 0.3.x
 
 ```ts
-import { OutboundMessageContext } from '@aries-framework/core' 
+import { OutboundMessageContext } from '@aries-framework/core'
 
 const outboundMessageContext = new OutboundMessageContext(message, {
-      agentContext: this.agentContext,
-      connection,
-      // optional, if you want to link the message to a related record
-      associatedRecord: record,  
-    })
+  agentContext: this.agentContext,
+  connection,
+  // optional, if you want to link the message to a related record
+  associatedRecord: record,
+})
 
 await this.messageSender.sendMessage(outboundMessageContext)
 ```

--- a/guides/updating/versions/0.2-to-0.3.md
+++ b/guides/updating/versions/0.2-to-0.3.md
@@ -66,6 +66,12 @@ For easy migration, you can simply construct `AgentOptions` by putting current I
 
 Note that, if you are defining `indyLedgers` configuration, you should set the indyNamespace for every ledger, as explained in [Agent Config tutorial](../../tutorials/agent-config/index.md#indyledgers).
 
+### did:key usage in protocols
+
+In accordance with [Aries RFC 0360](https://github.com/hyperledger/aries-rfcs/tree/b3a3942ef052039e73cd23d847f42947f8287da2/features/0360-use-did-key), since 0.2.5 there is a configuration parameter called `useDidKeyInProtocols` which, when enabled, will encode keys in did:key instead of previous base58 format, unless the other party has started a protocol and is using base58. 
+
+This parameter was previously disabled by default and now it is enabled. If your agent only interacts with modern agents (e.g. AFJ 0.2.5 and newer) this will not represent any issue. Otherwise it is safer to explicitly set it to `false`. However, keep in mind that we expect this setting to be deprecated in the future, so we encourage you to update all your agents to use did:key.
+
 ### Modules extracted from the core
 
 In this release two modules were extracted from the core and published as separate, optional packages:
@@ -441,6 +447,40 @@ AgentContext can be obtained from either:
 
     return record
   }
+```
+
+<!--/tabs-->
+
+#### Using OutboundMessageContext
+
+If your module implements a protocol that sends messages to other agents, you will notice that Agent's `MessageSender` now receives the more generic `OutboundMessageContext` class, which replaces previous helper method `createOutboundMessage`.
+
+You can take advantage of this new mechanism to associate a record to the context, in order to do specific actions to it when outbound message state changes (e.g. a `MessageSendingError` is thrown or `AgentMessageSentEvent` is emitted).
+
+<!--tabs-->
+
+#### 0.2.x
+
+```ts
+import { createOutboundMessage } from '@aries-framework/core' 
+
+const outboundMessage = createOutboundMessage(connection, message)
+await this.messageSender.sendMessage(outboundMessage)
+```
+
+#### 0.3.x
+
+```ts
+import { OutboundMessageContext } from '@aries-framework/core' 
+
+const outboundMessageContext = new OutboundMessageContext(message, {
+      agentContext: this.agentContext,
+      connection,
+      // optional, if you want to link the message to a related record
+      associatedRecord: record,  
+    })
+
+await this.messageSender.sendMessage(outboundMessageContext)
 ```
 
 <!--/tabs-->


### PR DESCRIPTION
Adding notes about `useDidKeyInProtocols` and `OutboundMessageContext`.