### PR TITLE
docs: small fixes and tweaks

### DIFF
--- a/guides/getting-started/index.md
+++ b/guides/getting-started/index.md
@@ -9,11 +9,11 @@ Based on the platform you want to work on, the installation guides you should fo
 **Do you want to build a mobile app?**
 
 - Follow the [Prerequisites](./prerequisites.md).
-- Follow the [Agent Setup](./set-up.md) guide.
+- Follow the [Agent Setup](./set-up) guide.
 
 **Do you want to build a server-side app?**
 
 - Follow the [Prerequisites](./prerequisites.md).
-- Follow the [Agent Setup](./set-up.md) guide.
+- Follow the [Agent Setup](./set-up) guide.
 
 <DocCardList  />

--- a/guides/getting-started/set-up/anoncreds-rs.md
+++ b/guides/getting-started/set-up/anoncreds-rs.md
@@ -1,10 +1,10 @@
-# Anoncreds RS
+# AnonCreds RS
 
 [AnonCreds RS](https://github.com/hyperledger/anoncreds-rs) is a direct implementation of the [AnonCreds V1.0 specification](https://hyperledger.github.io/anoncreds-spec/) that provides functionality like; creating a schema object, creating a credential definition object, creating a credential, verifying a proof presentation and much more.
 
 :::caution
 
-Support for the AnonCreds RS library in Aries Framework JavaScript is currently experimental. We recommend new projects to use AnonCreds RS from the start, and also to migrate existing projects to Anoncreds, from the Indy Sdk. However, projects may experience some issues. If you encounter any issues, please [open an issue](https://github.com/hyperledger/aries-framework-javascript/issues/new).
+Support for the AnonCreds RS library in Aries Framework JavaScript is currently experimental. We recommend new projects to use AnonCreds RS from the start, and also to migrate existing projects to AnonCreds, from the Indy Sdk. However, projects may experience some issues. If you encounter any issues, please [open an issue](https://github.com/hyperledger/aries-framework-javascript/issues/new).
 
 Currently, there are few limitations to using AnonCreds RS.
 

--- a/guides/getting-started/set-up/indy-vdr.md
+++ b/guides/getting-started/set-up/indy-vdr.md
@@ -58,23 +58,8 @@ After installing the dependencies, we can register the Indy VDR module on the ag
 
 As you can see below, the Indy VDR module takes the native bindings and a list of networks. This list of networks will be used to resolve and register objects on.
 
-```typescript title="example"
-import { indyVdr } from '@hyperledger/indy-vdr-nodejs'
-import { IndyVdrModule } from '@aries-framework/indy-vdr'
+```typescript typescript showLineNumbers set-up-indy-vdr-config.ts section-1
 
-const modules = {
-  indyVdr: new IndyVdrModule({
-    indyVdr,
-    networks: [
-      {
-        indyNamespace: 'bcovrin:test',
-        isProduction: false,
-        genesisTransaction: '<GENESIS_TRANSACTION>',
-        connectOnStartup: true,
-      },
-    ],
-  }),
-}
 ```
 
 #### indyVdr

--- a/snippets/current/src/set-up-indy-vdr-config.ts
+++ b/snippets/current/src/set-up-indy-vdr-config.ts
@@ -1,0 +1,18 @@
+// start-section-1
+import { indyVdr } from '@hyperledger/indy-vdr-nodejs'
+import { IndyVdrModule } from '@aries-framework/indy-vdr'
+
+const modules = {
+  indyVdr: new IndyVdrModule({
+    indyVdr,
+    networks: [
+      {
+        indyNamespace: 'bcovrin:test',
+        isProduction: false,
+        genesisTransactions: '<genesis_transactions>',
+        connectOnStartup: true,
+      },
+    ],
+  }),
+}
+// end-section-1


### PR DESCRIPTION
Fixes some typos, and extract the indy-vdr config to a snipper so we get hinting if it contains mistakes (the config contained `genesisTransaction` while it should be `genesisTransactions`