### PR TITLE
chore: add version to install scripts

### DIFF
--- a/guides/getting-started/set-up/anoncreds-rs.md
+++ b/guides/getting-started/set-up/anoncreds-rs.md
@@ -22,13 +22,13 @@ When using Aries Framework JavaScript with AnonCreds RS, there are a few extra d
 # Node.JS
 
 ```console
-yarn add @aries-framework/anoncreds @aries-framework/anoncreds-rs @hyperledger/anoncreds-nodejs
+yarn add @aries-framework/anoncreds@alpha @aries-framework/anoncreds-rs@alpha @hyperledger/anoncreds-nodejs
 ```
 
 # React Native
 
 ```console
-yarn add @aries-framework/anoncreds @aries-framework/anoncreds-rs @hyperledger/anoncreds-react-native
+yarn add @aries-framework/anoncreds@alpha @aries-framework/anoncreds-rs@alpha @hyperledger/anoncreds-react-native
 ```
 
 <!--/tabs-->

--- a/guides/getting-started/set-up/aries-askar.md
+++ b/guides/getting-started/set-up/aries-askar.md
@@ -27,13 +27,13 @@ When using Aries Framework JavaScript with Aries Askar, there are a few extra de
 # Node.JS
 
 ```console
-yarn add @aries-framework/askar @hyperledger/aries-askar-nodejs
+yarn add @aries-framework/askar@alpha @hyperledger/aries-askar-nodejs
 ```
 
 # React Native
 
 ```console
-yarn add @aries-framework/askar @hyperledger/aries-askar-react-native
+yarn add @aries-framework/askar@alpha @hyperledger/aries-askar-react-native
 ```
 
 <!--/tabs-->

--- a/guides/getting-started/set-up/index.md
+++ b/guides/getting-started/set-up/index.md
@@ -19,13 +19,13 @@ for configuring an Aries Framework JavaScript (AFJ) agent.
 # Node.JS
 
 ```console
-yarn add @aries-framework/core @aries-framework/node
+yarn add @aries-framework/core@alpha @aries-framework/node@alpha
 ```
 
 # React Native
 
 ```console
-yarn add @aries-framework/core @aries-framework/react-native react-native-fs react-native-get-random-values
+yarn add @aries-framework/core@alpha @aries-framework/react-native@alpha react-native-fs react-native-get-random-values
 ```
 
 <!--/tabs-->

--- a/guides/getting-started/set-up/indy-sdk/index.md
+++ b/guides/getting-started/set-up/indy-sdk/index.md
@@ -27,7 +27,7 @@ After the native Indy SDK library is installed, we can add the Indy SDK librarie
 # Node.JS
 
 ```console
-yarn add @aries-framework/indy-sdk indy-sdk
+yarn add @aries-framework/indy-sdk@alpha indy-sdk
 ```
 
 And install the needed types
@@ -39,7 +39,7 @@ yarn add --dev @types/indy-sdk
 # React Native
 
 ```console
-yarn add @aries-framework/indy-sdk indy-sdk-react-native
+yarn add @aries-framework/indy-sdk@alpha indy-sdk-react-native
 ```
 
 And then install the needed types

--- a/guides/getting-started/set-up/indy-vdr.md
+++ b/guides/getting-started/set-up/indy-vdr.md
@@ -23,13 +23,13 @@ When using Aries Framework JavaScript with Indy VDR, there are a few extra depen
 # Node.JS
 
 ```console
-yarn add @aries-framework/indy-vdr @hyperledger/indy-vdr-nodejs
+yarn add @aries-framework/indy-vdr@alpha @hyperledger/indy-vdr-nodejs
 ```
 
 # React Native
 
 ```console
-yarn add @aries-framework/indy-vdr @hyperledger/indy-vdr-react-native
+yarn add @aries-framework/indy-vdr@alpha @hyperledger/indy-vdr-react-native
 ```
 
 <!--/tabs-->

--- a/versioned_docs/version-0.3/getting-started/set-up/index.md
+++ b/versioned_docs/version-0.3/getting-started/set-up/index.md
@@ -14,13 +14,13 @@ for using the Aries Ecosystem.
 # Node.js
 
 ```console
-yarn add @aries-framework/core @aries-framework/node
+yarn add @aries-framework/core@^0.3.0 @aries-framework/node@^0.3.0
 ```
 
 # React Native
 
 ```console
-yarn add @aries-framework/core @aries-framework/react-native react-native-fs react-native-get-random-values indy-sdk-react-native
+yarn add @aries-framework/core@^0.3.0 @aries-framework/react-native@^0.3.0 react-native-fs react-native-get-random-values indy-sdk-react-native@^0.3.1
 ```
 
 <!--/tabs-->


### PR DESCRIPTION
Adds versions to install scripts so we don't have inconsistent installs. Before we release 0.4.0 we can update all `@alpha` tags to `@^0.4.0`