### PR TITLE
docs: note about installing under Windows

### DIFF
--- a/guides/getting-started/set-up/anoncreds-rs.md
+++ b/guides/getting-started/set-up/anoncreds-rs.md
@@ -9,6 +9,7 @@ Support for the AnonCreds RS library in Aries Framework JavaScript is currently 
 Currently, there are few limitations to using AnonCreds RS.
 
 - When running in Node.JS, only Node.JS 18 is supported for now. See [Supported Node.JS versions for AnonCreds RS](#supported-nodejs-versions-for-anoncreds-rs)
+- Install scripts rely on bash command substitution to get the proper binaries for each system architecture and platform. Therefore, if you are under Windows, you must configure `npm` or `yarn` to use a bash-compliant shell (e.g. `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`)
 
 :::
 

--- a/guides/getting-started/set-up/aries-askar.md
+++ b/guides/getting-started/set-up/aries-askar.md
@@ -8,6 +8,7 @@ Although Aries Askar is stable and already used in production in agents such as 
 Currently, there are few limitations to using Aries Askar.
 
 - When running in Node.JS, only Node.JS 18 is supported for now. See [Supported Node.JS versions for Aries Askar](#supported-nodejs-versions-for-aries-askar)
+- Install scripts rely on bash command substitution to get the proper binaries for each system architecture and platform. Therefore, if you are under Windows, you must configure `npm` or `yarn` to use a bash-compliant shell (e.g. `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`)
 
 :::
 

--- a/guides/getting-started/set-up/indy-vdr.md
+++ b/guides/getting-started/set-up/indy-vdr.md
@@ -9,6 +9,7 @@ Support for Indy VDR in Aries Framework JavaScript is currently experimental. We
 Currently, there are few limitations to using Indy VDR.
 
 - When running in Node.JS, only Node.JS 18 is supported for now. See [Supported Node.JS versions for Indy VDR](#supported-nodejs-versions-for-indy-vdr)
+- Install scripts rely on bash command substitution to get the proper binaries for each system architecture and platform. Therefore, if you are under Windows, you must configure `npm` or `yarn` to use a bash-compliant shell (e.g. `npm config set script-shell "C:\\Program Files\\git\\bin\\bash.exe"`)
 
 :::
 


### PR DESCRIPTION
Adds a note about the need of a bash-compliant shell for npm/yarn install commands, important for those who want to develop using native Windows.