### PR TITLE
fix: react native setup for cheqd

### DIFF
--- a/guides/getting-started/set-up/cheqd/index.md
+++ b/guides/getting-started/set-up/cheqd/index.md
@@ -58,10 +58,12 @@ Using [Yarn `resolutions`](https://classic.yarnpkg.com/lang/en/docs/selective-ve
 }
 ```
 
+<!--/tabs-->
+
 Following that we need to add a buffer polyfill
 
 ```console
-    yarn add buffer
+yarn add buffer
 ```
 
 create a shim.js file with the below code snippet
@@ -72,8 +74,6 @@ global.Buffer = Buffer
 ```
 
 `import shim.js` file into your file where the App is imported
-
-<!--/tabs-->
 
 ### Adding the cheqd to the Agent
 


### PR DESCRIPTION
tab was rendered at the wrong place, so it included some setup steps only in yarn setup, but it is also required in RN setup